### PR TITLE
update old function names (hermitian_eigen) in user guide

### DIFF
--- a/docs/user_guide/decompositions_and_lapack.mdx
+++ b/docs/user_guide/decompositions_and_lapack.mdx
@@ -25,7 +25,7 @@ LU with full pivoting    | $P^{-1} ~ L ~ U ~ Q^{-1}$ | `.full_piv_lu()`
 Hessenberg               | $P ~ H ~ P^*$             | `.hessenberg()`
 Cholesky                 | $L ~ L^*$                 | `.cholesky()`
 Schur decomposition      | $Q ~ U ~ Q^*$             | `.schur()` or `.try_schur(eps, max_iter)`
-Symmetric eigendecomposition | $U ~ \Lambda ~ U^*$   | `.hermitian_eigen()` or `.try_hermitian_eigen(eps, max_iter)`
+Symmetric eigendecomposition | $U ~ \Lambda ~ U^*$   | `.symmetric_eigen()` or `.try_symmetric_eigen(eps, max_iter)`
 SVD                      | $U ~ \Sigma ~ V^*$        | `.svd(compute_u, compute_v)` or `.try_svd(compute_u, compute_v, eps, max_iter)`
 
 All those methods return a dedicated data structure representing the


### PR DESCRIPTION
Hi! 
I found outdated function names in [Decompositions and Lapack](https://nalgebra.org/docs/user_guide/decompositions_and_lapack#linear-system-resolution) of the user guide.
The functions `hermitian_eigen` and `try_hermitian_eigen` have changed to `symmetric_eigen` and `try_symmetric_eigen`, so I have modified the names of these functions.